### PR TITLE
Fix NSCoding implementation to use proper encode/decode methods

### DIFF
--- a/lib/immutabler/dsl/mapping.rb
+++ b/lib/immutabler/dsl/mapping.rb
@@ -8,7 +8,7 @@ module Immutabler
         @destination_name = destination_name
         @type = options[:type]
         @is_array = options.fetch(:array, false)
-        @is_dict  = options.fetch(:dict,  false)
+        @is_dict = options.fetch(:dict, false)
         @custom_transformer = options[:with]
         @dict_mappings = []
       end

--- a/lib/immutabler/template/body_template.rb
+++ b/lib/immutabler/template/body_template.rb
@@ -14,9 +14,7 @@ module Immutabler
           body = "@{\n"
 
           if arg
-            body << arg.map{|m|
-              "@\"#{m.destination_name}\" : @\"#{m.origin_name}\""
-            }.join(",\n")
+            body << arg.map { |m| "@\"#{m.destination_name}\" : @\"#{m.origin_name}\"" }.join(",\n")
           end
 
           body << "\n};"
@@ -26,9 +24,7 @@ module Immutabler
           body = "@{\n"
 
           if arg
-            body << arg.map{|m|
-              "@\"#{m.origin_name}\" : @(#{m.destination_name})"
-            }.join(",\n")
+            body << arg.map { |m| "@\"#{m.origin_name}\" : @(#{m.destination_name})" }.join(",\n")
           end
 
           body << "\n};"
@@ -49,47 +45,45 @@ module Immutabler
             "    self = [super init];\n"
           end
         end
-        
+
         helper(:decodeProperty) do |context, arg, block|
-            decl = if arg.type == 'BOOL'
-                        "        _#{arg.name} = [coder decodeBoolForKey:@\"_#{arg.name}\"];"
-                    elsif arg.type == 'NSInteger'
-                        "        if (sizeof(_#{arg.name}) < 8) {\n            \
+          case arg.type
+            when 'BOOL'
+              "        _#{arg.name} = [coder decodeBoolForKey:@\"_#{arg.name}\"];"
+            when 'NSInteger'
+              "        if (sizeof(_#{arg.name}) < 8) {\n            \
                         _#{arg.name} = [coder decodeInt32ForKey:@\"_#{arg.name}\"];\n\
                         }\n\
                         else {\n\
                         _#{arg.name} = [coder decodeInt64ForKey:@\"_#{arg.name}\"]; \n\
                         }"
-                    elsif arg.type == 'CGFloat'
-                        "        _#{arg.name} = [coder decodeFloatForKey:@\"_#{arg.name}\"];"
-                    elsif arg.type == 'double'
-                        "        _#{arg.name} = [coder decodeDoubleForKey:@\"_#{arg.name}\"];"
-                    else
-                        "        _#{arg.name} = [coder decodeObjectForKey:@\"_#{arg.name}\"];"
-                    end
-
-            decl
+            when 'CGFloat'
+              "        _#{arg.name} = [coder decodeFloatForKey:@\"_#{arg.name}\"];"
+            when 'double'
+              "        _#{arg.name} = [coder decodeDoubleForKey:@\"_#{arg.name}\"];"
+            else
+              "        _#{arg.name} = [coder decodeObjectForKey:@\"_#{arg.name}\"];"
+          end
         end
 
         helper(:encodeProperty) do |context, arg, block|
-            decl = if arg.type == 'BOOL'
-                        "        [coder encodeBool:self.#{arg.name} forKey:@\"_#{arg.name}\"];"
-                    elsif arg.type == 'NSInteger'
-                        "        if (sizeof(_#{arg.name}) < 8) {\n            \
+          case arg.type
+            when 'BOOL'
+              "        [coder encodeBool:self.#{arg.name} forKey:@\"_#{arg.name}\"];"
+            when 'NSInteger'
+              "        if (sizeof(_#{arg.name}) < 8) {\n            \
                         [coder encodeInt32:self.#{arg.name} forKey:@\"_#{arg.name}\"];\n\
                         }\n\
                         else {\n\
                         [coder encodeInt64:self.#{arg.name} forKey:@\"_#{arg.name}\"]; \n\
                         }"
-                    elsif arg.type == 'CGFloat'
-                        "        [coder encodeFloat:self.#{arg.name} forKey:@\"_#{arg.name}\"];"
-                    elsif arg.type == 'double'
-                        "        [coder encodeDouble:self.#{arg.name} forKey:@\"_#{arg.name}\"];"
-                    else
-                        "        [coder encodeObject:self.#{arg.name} forKey:@\"_#{arg.name}\"];"
-                    end
-
-            decl
+            when 'CGFloat'
+              "        [coder encodeFloat:self.#{arg.name} forKey:@\"_#{arg.name}\"];"
+            when 'double'
+              "        [coder encodeDouble:self.#{arg.name} forKey:@\"_#{arg.name}\"];"
+            else
+              "        [coder encodeObject:self.#{arg.name} forKey:@\"_#{arg.name}\"];"
+          end
         end
 
         helper(:base_immutable_interface) do |context, arg, block|

--- a/lib/immutabler/template/body_template.rb
+++ b/lib/immutabler/template/body_template.rb
@@ -49,6 +49,48 @@ module Immutabler
             "    self = [super init];\n"
           end
         end
+        
+        helper(:decodeProperty) do |context, arg, block|
+            decl = if arg.type == 'BOOL'
+                        "        _#{arg.name} = [coder decodeBoolForKey:@\"_#{arg.name}\"];"
+                    elsif arg.type == 'NSInteger'
+                        "        if (sizeof(_#{arg.name}) < 8) {\n            \
+                        _#{arg.name} = [coder decodeInt32ForKey:@\"_#{arg.name}\"];\n\
+                        }\n\
+                        else {\n\
+                        _#{arg.name} = [coder decodeInt64ForKey:@\"_#{arg.name}\"]; \n\
+                        }"
+                    elsif arg.type == 'CGFloat'
+                        "        _#{arg.name} = [coder decodeFloatForKey:@\"_#{arg.name}\"];"
+                    elsif arg.type == 'double'
+                        "        _#{arg.name} = [coder decodeDoubleForKey:@\"_#{arg.name}\"];"
+                    else
+                        "        _#{arg.name} = [coder decodeObjectForKey:@\"_#{arg.name}\"];"
+                    end
+
+            decl
+        end
+
+        helper(:encodeProperty) do |context, arg, block|
+            decl = if arg.type == 'BOOL'
+                        "        [coder encodeBool:self.#{arg.name} forKey:@\"_#{arg.name}\"];"
+                    elsif arg.type == 'NSInteger'
+                        "        if (sizeof(_#{arg.name}) < 8) {\n            \
+                        [coder encodeInt32:self.#{arg.name} forKey:@\"_#{arg.name}\"];\n\
+                        }\n\
+                        else {\n\
+                        [coder encodeInt64:self.#{arg.name} forKey:@\"_#{arg.name}\"]; \n\
+                        }"
+                    elsif arg.type == 'CGFloat'
+                        "        [coder encodeFloat:self.#{arg.name} forKey:@\"_#{arg.name}\"];"
+                    elsif arg.type == 'double'
+                        "        [coder encodeDouble:self.#{arg.name} forKey:@\"_#{arg.name}\"];"
+                    else
+                        "        [coder encodeObject:self.#{arg.name} forKey:@\"_#{arg.name}\"];"
+                    end
+
+            decl
+        end
 
         helper(:base_immutable_interface) do |context, arg, block|
           if arg[:base_immutable]

--- a/lib/immutabler/template/builder.rb
+++ b/lib/immutabler/template/builder.rb
@@ -26,7 +26,7 @@ module Immutabler
             props: build_props(model.props),
             any_mappings: model.mappings.any?,
             array_mappings: model.mappings.select(&:array?),
-            dict_mappings:  build_dict_mappings(model.mappings),
+            dict_mappings: build_dict_mappings(model.mappings),
             custom_mappers: build_custom_mappers(model.mappings),
             mappings: build_mappings(model.mappings)
           }
@@ -53,7 +53,7 @@ module Immutabler
         mappings.select(&:dict?).map do |mapping|
           attributes = mapping.dict_mappings.map do |dict_mapping|
             {
-              origin_name:      dict_mapping[:origin_name],
+              origin_name: dict_mapping[:origin_name],
               destination_name: dict_mapping[:destination_name]
             }
           end

--- a/lib/immutabler/template/header_template.rb
+++ b/lib/immutabler/template/header_template.rb
@@ -26,10 +26,10 @@ module Immutabler
             options = block[:hash]
             access_type = options[:readOnly] ? 'readonly' : 'readwrite'
             asterisk = prop[:is_ref] && !prop[:is_id] ? '*' : ''
-            asterisk_and_prefix =  "#{asterisk}#{prop[:name_prefix]}"
+            asterisk_and_prefix = "#{asterisk}#{prop[:name_prefix]}"
             memory_management = prop[:is_ref] ? prop[:ref_type] : 'assign';
             prop_arguments = "@property(nonatomic, #{memory_management}, #{access_type})"
-            prop_field = "#{prop[:type]} #{asterisk_and_prefix}#{prop[:name]}"            
+            prop_field = "#{prop[:type]} #{asterisk_and_prefix}#{prop[:name]}"
             "#{prop_arguments} #{prop_field};"
           end.join("\n")
         end
@@ -45,7 +45,7 @@ module Immutabler
 
       def build_enums(enums)
         enums.map do |enum|
-          attributes = enum.attributes.map { |attr| { name: attr.name } }
+          attributes = enum.attributes.map { |attr| {name: attr.name} }
 
           {
             name: enum.name,

--- a/lib/immutabler/type_mapper.rb
+++ b/lib/immutabler/type_mapper.rb
@@ -12,7 +12,7 @@ module Immutabler
       'double' => {
         type: 'double',
         is_ref: false
-      },      
+      },
       'bool' => {
         type: 'BOOL',
         is_ref: false

--- a/lib/immutabler/version.rb
+++ b/lib/immutabler/version.rb
@@ -1,3 +1,3 @@
 module Immutabler
-  VERSION = '0.2.1'
+  VERSION = '0.2.2'
 end

--- a/templates/body_template.hbs
+++ b/templates/body_template.hbs
@@ -139,18 +139,8 @@
     {{#init_with_coder .}}
     {{/init_with_coder}}
     if (self) {
-        {{#props}}
-        {{#is_ref}}
-        _{{name}} = [coder decodeObjectForKey:@"_{{name}}"];
-        {{/is_ref}}
-        {{^is_ref}}
-        if (sizeof(_{{name}}) < 8) {
-        	_{{name}} = [coder decodeInt32ForKey:@"_{{name}}"];
-        }
-        else {
-        	_{{name}} = [coder decodeInt64ForKey:@"_{{name}}"];
-        }
-        {{/is_ref}}
+        {{#props}}        
+        {{#decodeProperty this}}{{/decodeProperty}}
         {{/props}}
         __modelVersion = [coder decodeIntegerForKey:@"__modelVersion"];
     }
@@ -159,18 +149,8 @@
 }
 
 - (void)encodeWithCoder:(NSCoder *)coder {
-    {{#props}}
-    {{#is_ref}}
-    [coder encodeObject:self.{{name}} forKey:@"_{{name}}"];
-    {{/is_ref}}
-    {{^is_ref}}
-	if (sizeof(_{{name}}) < 8) {
-		[coder encodeInt32:self.{{name}} forKey:@"_{{name}}"];
-	}
-	else {
-		[coder encodeInt64:self.{{name}} forKey:@"_{{name}}"];	
-	}    
-    {{/is_ref}}
+    {{#props}}       
+    {{#encodeProperty this}}{{/encodeProperty}}
     {{/props}}
     [coder encodeInteger:__modelVersion forKey:@"__modelVersion"];
 }


### PR DESCRIPTION
Old NSCoding implementation encode/decode all primitive types as integers. 
This PR fix using proper methods for encode/decode float/double/bool etc.
