### PR TITLE
Add gen_equatable option to model template

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -43,7 +43,14 @@ model :User, base: MyModel, base_immutable: true do
 end
 ```
 
-You can specify base class for model builder using `builder_base` option:
+You can avoid generating `isEqual:` method for you by specifying `gen_equatable` option to `false` (`true` by default):
+```ruby
+model :User, gen_equatable: false do
+
+end
+```
+
+You can specify base class for model builder using `builder_base` option (`NSObject` by default):
 
 ```ruby
 model :User, builder_base: :CustomBuilder do

--- a/lib/immutabler/dsl/group.rb
+++ b/lib/immutabler/dsl/group.rb
@@ -50,11 +50,12 @@ module Immutabler
         prefix = @prefix + name.to_s
         base = options.fetch(:base, @base_model).to_s
         base_immutable = options.fetch(:base_immutable, false)
-        builder_base = options.fetch(:builder_base, base).to_s
+        gen_equatable = options.fetch(:gen_equatable, true)
+        builder_base = options.fetch(:builder_base, 'NSObject').to_s
         props = []
         ModelAttributesBuilder.new(props, &block)
 
-        model = Model.new(prefix, base, base_immutable, builder_base, props)
+        model = Model.new(prefix, base, base_immutable, gen_equatable, builder_base, props)
 
         models << model
       end

--- a/lib/immutabler/dsl/model.rb
+++ b/lib/immutabler/dsl/model.rb
@@ -1,12 +1,13 @@
 module Immutabler
   module DSL
     class Model
-      attr_accessor :name, :base, :base_immutable, :builder_base, :props
+      attr_accessor :name, :base, :base_immutable, :gen_equatable, :builder_base, :props
 
-      def initialize(name, base, base_immutable, builder_base, props)
+      def initialize(name, base, base_immutable, gen_equatable, builder_base, props)
         @name = name
         @base = base
         @base_immutable = base_immutable
+        @gen_equatable = gen_equatable 
         @builder_base = builder_base
         @props = props
       end

--- a/lib/immutabler/template/builder.rb
+++ b/lib/immutabler/template/builder.rb
@@ -22,6 +22,7 @@ module Immutabler
             name: model.name,
             base_class: model.base,
             base_immutable: model.base_immutable,
+            gen_equatable: model.gen_equatable,
             builder_base_class: model.builder_base,
             props: build_props(model.props),
           }

--- a/templates/body_template.hbs
+++ b/templates/body_template.hbs
@@ -13,8 +13,7 @@
     NSInteger __modelVersion;
 }
 
-+ ({{name}}*)create:(void(^)({{name}}Builder *builder))builderBlock
-{
++ (instancetype)create:(void(^)({{name}}Builder *builder))builderBlock {
     {{name}}Builder *builder = [{{name}}Builder new];
     if(builderBlock)
     {
@@ -23,14 +22,12 @@
     return [[self alloc] initWithBuilder:builder modelVersion:1];
 }
 
-- (instancetype)init
-{
+- (instancetype)init {
     {{name}}Builder *builder = [{{name}}Builder new];
     return [[[self class] alloc] initWithBuilder:builder modelVersion:1];
 }
 
-- (instancetype)initWithBuilder:({{name}}Builder*)builder modelVersion:(NSInteger)modelVersion
-{
+- (instancetype)initWithBuilder:({{name}}Builder*)builder modelVersion:(NSInteger)modelVersion {
     {{#init_with_builder .}}
     {{/init_with_builder}}
 
@@ -44,8 +41,7 @@
     return self;
 }
 
-- ({{name}}*)mutate:(void(^)({{name}}Builder *builder))builderBlock
-{
+- (instancetype)mutate:(void(^)({{name}}Builder *builder))builderBlock {
     {{name}}Builder *builder = [{{name}}Builder new];
 
     {{#props}}
@@ -57,6 +53,7 @@
     return [[[self class] alloc] initWithBuilder:builder modelVersion:__modelVersion + 1];
 }
 
+{{#gen_equatable}}
 - (BOOL)isEqual:(id)other {
     if (other == self)
         return YES;
@@ -77,7 +74,7 @@
     {{/props}}
     return YES;
 }
-
+{{/gen_equatable}}
 - (NSUInteger)hash {
     NSUInteger hash = 0;
     {{#props}}
@@ -106,7 +103,7 @@
     return description;
 }
 
-- (id)initWithCoder:(NSCoder *)coder {
+- (instancetype)initWithCoder:(NSCoder *)coder {
     {{#init_with_coder .}}
     {{/init_with_coder}}
     if (self) {
@@ -126,7 +123,7 @@
     [coder encodeInteger:__modelVersion forKey:@"__modelVersion"];
 }
 
-- (id)copyWithZone:(NSZone *)zone {
+- (instancetype)copyWithZone:(NSZone *)zone {
     {{name}} *copy = [[[self class] allocWithZone:zone] init];
 
     if (copy != nil) {
@@ -138,7 +135,6 @@
 
     return copy;
 }
-
 
 @end
 

--- a/templates/header_template.hbs
+++ b/templates/header_template.hbs
@@ -22,8 +22,8 @@
 {{/declare_props}}
 
 
-+ ({{name}}*)create:(void(^)({{name}}Builder *builder))builder;
-- ({{name}}*)mutate:(void(^)({{name}}Builder *builder))builder;
++ (instancetype)create:(void(^)({{name}}Builder *builder))builder;
+- (instancetype)mutate:(void(^)({{name}}Builder *builder))builder;
 
 
 {{/interface}}


### PR DESCRIPTION
This allows opting out of generated `isEqual:` template.  
Motivation:   
Sometimes you might want to specify custom equatable in the category.
Solution:  
Add new `gen_equatable: bool` option in the model parameters which is `true` by default (so it won't break previously generated code).

Some enhancements:  
- all constructors and mutators return `instancetype`;
- model builder is `NSObject` by default.